### PR TITLE
Order fields in a sane way

### DIFF
--- a/src/overlay.js
+++ b/src/overlay.js
@@ -34,6 +34,21 @@ function applyOverlayToOpenAPI(spec, overlay) {
 	return spec;
 }
 
+function sortOpenAPIFields(field1, field2) {
+    const orderedKeys = ["info", "servers", "paths", "components", "summary", "objectId", "description", "tags", "parameters", "responses"];
+
+    const index1 = orderedKeys.indexOf(field1);
+    const index2 = orderedKeys.indexOf(field2);
+
+    if (index1 === -1 || index2 === -1) {
+        return 0;
+    } else if (index1 > index2) {
+        return 1;
+    } else {
+        return -1;
+    }
+}
+
 export function overlayFiles(openapiFile, overlayFile) {
 	// Parse the "input" OpenAPI document
 	const specraw = fs.readFileSync(openapiFile, 'utf8');
@@ -46,7 +61,7 @@ export function overlayFiles(openapiFile, overlayFile) {
 	spec = applyOverlayToOpenAPI(spec, overlay);
 
 	// Return the new spec
-	return safeStringify(spec);
-
+	return safeStringify(spec, {"sortKeys": sortOpenAPIFields});
 }
+
 

--- a/test/expected/output1.yaml
+++ b/test/expected/output1.yaml
@@ -10,6 +10,9 @@ paths:
   /pets:
     get:
       operationId: listPets
+      info:
+        x-overlay-applied: structured-overlay
+        description: This is an added description
       tags:
         - pets
         - wildcard-done
@@ -41,9 +44,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-      info:
-        x-overlay-applied: structured-overlay
-        description: This is an added description
     post:
       foo:
         bar: hello


### PR DESCRIPTION
When we add, for example, a description field, it gets added as the last property in the object. Which is _techically_ correct, but not that friendly to humans who want to use/read the output of this tool. This adds a field ordering step so that, for example, description appears before parameters.