### PR TITLE
Add arg library, publish as overlayjs command

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,34 @@
+#!/usr/bin/env node
+import arg from 'arg';
 import {overlayFiles} from './src/overlay.js'
 
-// example: node index.js test/openapi/petstore.yaml test/overlays/overlay.yaml
-const openapiFile = process.argv[2]
-const overlayFile = process.argv[3]
-var spec = overlayFiles(openapiFile, overlayFile);
-console.log(spec);
+function showHelp() {
+    console.log("Usage: overlayjs --openapi FILEPATH --overlay FILEPATH");
+    console.log("    use --help to see this help");
+}
+
+try {
+    const args = arg({
+        '--openapi': String,
+        '--overlay': String,
+        '--help': String
+    });
+
+    if(args['--overlay'] && args['--openapi']) {
+        const openapiFile = args['--openapi'];
+        const overlayFile = args['--overlay'];
+        var spec = overlayFiles(openapiFile, overlayFile);
+        console.log(spec);
+    } else {
+        showHelp()
+    }
+
+} catch (err) {
+    if (err.code === 'ARG_UNKNOWN_OPTION') {
+        console.warn(err.message);
+        showHelp()
+    } else {
+        throw err;
+    }
+}
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "bin": {
+      "overlayjs": "./index.js"
+  },
   "scripts": {
     "test": "node_modules/.bin/jest"
   },
@@ -11,6 +14,7 @@
   "license": "Apache2",
   "dependencies": {
     "@stoplight/yaml": "^4.2.3",
+    "arg": "^5.0.2",
     "jsonpath": "^1.1.1",
     "mergician": "^1.0.3",
     "openapi-format": "^1.13.0"


### PR DESCRIPTION
The idea is to publish this as a command line utility so this adds [arg](https://www.npmjs.com/package/arg) as a dependency, and makes an `overlayjs` command that's available if you `npm install -g`.

Usage example: `node index.js --openapi test/openapi/petstore.yaml --overlay test/overlays/overlay.yaml` for the happy path.

README file coming in a separate PR...