### PR TITLE
remove: improve removal of array items

### DIFF
--- a/src/overlay.js
+++ b/src/overlay.js
@@ -15,7 +15,11 @@ function applyOverlayToOpenAPI(spec, overlay) {
 				}
 				var parent = jsonpath.parent(spec, a.target)
 				const thingToRemove = path[0][path[0].length - 1]
-				delete parent[thingToRemove]
+				if (Array.isArray(parent)) {
+					parent.splice(thingToRemove, 1);
+				} else {
+					delete parent[thingToRemove];
+				}
 			}
 
 		} else {

--- a/test/expected/one-less-server.yaml
+++ b/test/expected/one-less-server.yaml
@@ -1,0 +1,8 @@
+openapi: 3.1.0
+info:
+  title: API servers
+  version: 1.0.0
+servers:
+  - url: 'https://api.example.com'
+    description: Production
+paths: {}

--- a/test/openapi/openapi-with-servers.yaml
+++ b/test/openapi/openapi-with-servers.yaml
@@ -1,0 +1,10 @@
+openapi: 3.1.0
+info:
+  title: API servers
+  version: 1.0.0
+servers:
+  - url: 'https://api.dev.example.com'
+    description: Dev
+  - url: 'https://api.example.com'
+    description: Production
+paths: {}

--- a/test/overlay.test.js
+++ b/test/overlay.test.js
@@ -59,6 +59,17 @@ test('remove all description fields', () => {
 	expect(result).toEqual(expectedOutput);
 });
 
+test('remove a server array entry', () => {
+	const openapiFile = "test/openapi/openapi-with-servers.yaml";
+	const overlayFile = "test/overlays/remove-server.yaml";
+	const expectedFile = "test/expected/one-less-server.yaml";
+	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+
+	const result = overlayFiles(openapiFile, overlayFile);
+
+	expect(result).toEqual(expectedOutput);
+});
+
 test('fail to update a primitive string type', () => {
 	const openapiFile = "test/openapi/immutable.yaml";
 	const overlayFile = "test/overlays/immutable.yaml";

--- a/test/overlays/remove-server.yaml
+++ b/test/overlays/remove-server.yaml
@@ -1,0 +1,9 @@
+overlay: 1.0.0
+info:
+  title: Remove dev server
+  version: 1.0.0
+extends: openapi-with-servers.yaml
+
+actions:
+  - target: $.servers[?( @.description == 'Dev' )]
+    remove: true


### PR DESCRIPTION
This commit improves the “remove” action of overlays when targeting an
array element.

Instead of using `delete` on the array item, we remove the item from
the array completely with
[`Array.prototype.splice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice)
method.

This avoids ending up with `undefined` values in arrays of the
resulting API description.