### PR TITLE
Add NodeJS 20.x to the build matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I noticed we only test on versions up to 18.x, so let's add 20.x as it's current.