### PR TITLE
Fix broken --help option

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ try {
     const args = arg({
         '--openapi': String,
         '--overlay': String,
-        '--help': String
+        '--help': Boolean,
     });
 
     if(args['--overlay'] && args['--openapi']) {


### PR DESCRIPTION
The `--help` is not helpful as it outputs an error! The arg should be boolean to stop it needing a value with it.