### PR TITLE
style: use 'standard' eslint rules to have a consistent code style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "mocha": true,
+    "jest": true
+  },
+  "extends": "standard",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+  }
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,4 +22,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
+      - run: npm run lint
       - run: npm test

--- a/index.js
+++ b/index.js
@@ -1,34 +1,32 @@
 #!/usr/bin/env node
-import arg from 'arg';
-import {overlayFiles} from './src/overlay.js'
+import arg from 'arg'
+import { overlayFiles } from './src/overlay.js'
 
-function showHelp() {
-    console.log("Usage: overlayjs --openapi FILEPATH --overlay FILEPATH");
-    console.log("    use --help to see this help");
+function showHelp () {
+  console.log('Usage: overlayjs --openapi FILEPATH --overlay FILEPATH')
+  console.log('    use --help to see this help')
 }
 
 try {
-    const args = arg({
-        '--openapi': String,
-        '--overlay': String,
-        '--help': String
-    });
+  const args = arg({
+    '--openapi': String,
+    '--overlay': String,
+    '--help': String
+  })
 
-    if(args['--overlay'] && args['--openapi']) {
-        const openapiFile = args['--openapi'];
-        const overlayFile = args['--overlay'];
-        var spec = overlayFiles(openapiFile, overlayFile);
-        console.log(spec);
-    } else {
-        showHelp()
-    }
-
+  if (args['--overlay'] && args['--openapi']) {
+    const openapiFile = args['--openapi']
+    const overlayFile = args['--overlay']
+    const spec = overlayFiles(openapiFile, overlayFile)
+    console.log(spec)
+  } else {
+    showHelp()
+  }
 } catch (err) {
-    if (err.code === 'ARG_UNKNOWN_OPTION') {
-        console.warn(err.message);
-        showHelp()
-    } else {
-        throw err;
-    }
+  if (err.code === 'ARG_UNKNOWN_OPTION') {
+    console.warn(err.message)
+    showHelp()
+  } else {
+    throw err
+  }
 }
-

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "",
   "main": "index.js",
   "bin": {
-      "overlayjs": "./index.js"
+    "overlayjs": "./index.js"
   },
   "scripts": {
-    "test": "node_modules/.bin/jest"
+    "test": "node_modules/.bin/jest",
+    "lint": "eslint . --config .eslintrc.json",
+    "fmt": "eslint . --config .eslintrc.json --fix"
   },
   "type": "module",
   "author": "",
@@ -23,6 +25,11 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "babel-jest": "^29.4.1",
+    "eslint": "^8.57.0",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.4.1"
   },
   "jest": {

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -57,6 +57,10 @@ function sortOpenAPIFields(field1, field2) {
 	}
 }
 
+export function applyOverlay(definition, overlay) {
+        return applyOverlayToOpenAPI(definition, overlay);
+}
+
 export function overlayFiles(openapiFile, overlayFile) {
 	// Parse the "input" OpenAPI document
 	const specraw = fs.readFileSync(openapiFile, 'utf8');

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -1,79 +1,76 @@
-import fs from 'fs';
-import jsonpath from 'jsonpath';
-import {safeStringify,parse,parseWithPointers} from "@stoplight/yaml";
-import mergician from 'mergician';
+import fs from 'fs'
+import jsonpath from 'jsonpath'
+import { safeStringify, parseWithPointers } from '@stoplight/yaml'
+import mergician from 'mergician'
 
-function applyOverlayToOpenAPI(spec, overlay) {
-	// Use jsonpath.apply to do the changes
-	if (overlay.actions && overlay.actions.length >= 1) overlay.actions.forEach((a)=>{
-		// Is it a remove?
-		if (a.hasOwnProperty('remove')) {
-			while(true) {
-				var path = jsonpath.paths(spec, a.target)
-				if (path.length == 0) {
-					break
-				}
-				var parent = jsonpath.parent(spec, a.target)
-				const thingToRemove = path[0][path[0].length - 1]
-				if (Array.isArray(parent)) {
-					parent.splice(thingToRemove, 1);
-				} else {
-					delete parent[thingToRemove];
-				}
-			}
+function applyOverlayToOpenAPI (spec, overlay) {
+  // Use jsonpath.apply to do the changes
+  if (overlay.actions && overlay.actions.length >= 1) {
+    overlay.actions.forEach((a) => {
+    // Is it a remove?
+      if (Object.prototype.hasOwnProperty.call(a, 'remove')) {
+        while (true) {
+          const path = jsonpath.paths(spec, a.target)
+          if (path.length === 0) {
+            break
+          }
+          const parent = jsonpath.parent(spec, a.target)
+          const thingToRemove = path[0][path[0].length - 1]
+          if (Array.isArray(parent)) {
+            parent.splice(thingToRemove, 1)
+          } else {
+            delete parent[thingToRemove]
+          }
+        }
+      } else {
+        try {
+        // It must be an update
+          jsonpath.apply(spec, a.target, (chunk) => {
+          // Deep merge using a module (built-in spread operator is only shallow)
+            const merger = mergician({ appendArrays: true })
+            return merger(chunk, a.update)
+          })
+        } catch (ex) {
+          process.stderr.write(`Error applying overlay: ${ex.message}\n`)
+        // return chunk
+        }
+      }
+    })
+  }
 
-		} else {
-			try {
-				// It must be an update
-				jsonpath.apply(spec, a.target, (chunk) => {
-					// Deep merge using a module (built-in spread operator is only shallow)
-					const merger = mergician({appendArrays: true})
-					return merger(chunk, a.update)
-				});
-			}
-			catch (ex) {
-				process.stderr.write(`Error applying overlay: ${ex.message}\n`)
-				//return chunk
-			}
-
-		}
-	})
-
-	return spec;
+  return spec
 }
 
-function sortOpenAPIFields(field1, field2) {
-	const orderedKeys = ["info", "servers", "summary", "operationId", "tags", "paths", "components", "description", "parameters", "responses"];
+function sortOpenAPIFields (field1, field2) {
+  const orderedKeys = ['info', 'servers', 'summary', 'operationId', 'tags', 'paths', 'components', 'description', 'parameters', 'responses']
 
-	const index1 = orderedKeys.indexOf(field1);
-	const index2 = orderedKeys.indexOf(field2);
+  const index1 = orderedKeys.indexOf(field1)
+  const index2 = orderedKeys.indexOf(field2)
 
-	if (index1 === -1 || index2 === -1) {
-		return 0;
-	} else if (index1 > index2) {
-		return 1;
-	} else {
-		return -1;
-	}
+  if (index1 === -1 || index2 === -1) {
+    return 0
+  } else if (index1 > index2) {
+    return 1
+  } else {
+    return -1
+  }
 }
 
-export function applyOverlay(definition, overlay) {
-        return applyOverlayToOpenAPI(definition, overlay);
+export function applyOverlay (definition, overlay) {
+  return applyOverlayToOpenAPI(definition, overlay)
 }
 
-export function overlayFiles(openapiFile, overlayFile) {
-	// Parse the "input" OpenAPI document
-	const specraw = fs.readFileSync(openapiFile, 'utf8');
-	var spec = parseWithPointers(specraw).data;
+export function overlayFiles (openapiFile, overlayFile) {
+  // Parse the "input" OpenAPI document
+  const specraw = fs.readFileSync(openapiFile, 'utf8')
+  let spec = parseWithPointers(specraw).data
 
-	// Parse the "overlay" document
-	const overlayraw = fs.readFileSync(overlayFile, 'utf8');
-	const overlay = parseWithPointers(overlayraw).data;
+  // Parse the "overlay" document
+  const overlayraw = fs.readFileSync(overlayFile, 'utf8')
+  const overlay = parseWithPointers(overlayraw).data
 
-	spec = applyOverlayToOpenAPI(spec, overlay);
+  spec = applyOverlayToOpenAPI(spec, overlay)
 
-	// Return the new spec
-	return safeStringify(spec, {"sortKeys": sortOpenAPIFields});
+  // Return the new spec
+  return safeStringify(spec, { sortKeys: sortOpenAPIFields })
 }
-
-

--- a/test/overlay.test.js
+++ b/test/overlay.test.js
@@ -1,127 +1,123 @@
-import {overlayFiles} from '../src/overlay.js'
-import fs from 'fs';
-
+import { overlayFiles } from '../src/overlay.js'
+import fs from 'fs'
 
 test('apply an overlay and check the output', () => {
-	const openapiFile = "test/openapi/petstore.yaml";
-	const overlayFile = "test/overlays/overlay.yaml";
-	const expectedFile = "test/expected/output1.yaml";
-	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+  const openapiFile = 'test/openapi/petstore.yaml'
+  const overlayFile = 'test/overlays/overlay.yaml'
+  const expectedFile = 'test/expected/output1.yaml'
+  const expectedOutput = fs.readFileSync(expectedFile, 'utf8')
 
-	const result = overlayFiles(openapiFile, overlayFile);
+  const result = overlayFiles(openapiFile, overlayFile)
 
-	expect(result).toEqual(expectedOutput);
-});
+  expect(result).toEqual(expectedOutput)
+})
 
 test('add a description and update the summary', () => {
-	const openapiFile = "test/openapi/town.yaml";
-	const overlayFile = "test/overlays/building-description.yaml";
-	const expectedFile = "test/expected/town-building-description.yaml";
-	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+  const openapiFile = 'test/openapi/town.yaml'
+  const overlayFile = 'test/overlays/building-description.yaml'
+  const expectedFile = 'test/expected/town-building-description.yaml'
+  const expectedOutput = fs.readFileSync(expectedFile, 'utf8')
 
-	const result = overlayFiles(openapiFile, overlayFile);
+  const result = overlayFiles(openapiFile, overlayFile)
 
-	expect(result).toEqual(expectedOutput);
-});
-
+  expect(result).toEqual(expectedOutput)
+})
 
 test('remove an example', () => {
-	const openapiFile = "test/openapi/town.yaml";
-	const overlayFile = "test/overlays/remove-example.yaml";
-	const expectedFile = "test/expected/town-remove-example.yaml";
-	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+  const openapiFile = 'test/openapi/town.yaml'
+  const overlayFile = 'test/overlays/remove-example.yaml'
+  const expectedFile = 'test/expected/town-remove-example.yaml'
+  const expectedOutput = fs.readFileSync(expectedFile, 'utf8')
 
-	const result = overlayFiles(openapiFile, overlayFile);
+  const result = overlayFiles(openapiFile, overlayFile)
 
-	expect(result).toEqual(expectedOutput);
-});
-
+  expect(result).toEqual(expectedOutput)
+})
 
 test('remove a property', () => {
-	const openapiFile = "test/openapi/town.yaml";
-	const overlayFile = "test/overlays/remove-properties.yaml";
-	const expectedFile = "test/expected/town-remove-properties.yaml";
-	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+  const openapiFile = 'test/openapi/town.yaml'
+  const overlayFile = 'test/overlays/remove-properties.yaml'
+  const expectedFile = 'test/expected/town-remove-properties.yaml'
+  const expectedOutput = fs.readFileSync(expectedFile, 'utf8')
 
-	const result = overlayFiles(openapiFile, overlayFile);
+  const result = overlayFiles(openapiFile, overlayFile)
 
-	expect(result).toEqual(expectedOutput);
-});
+  expect(result).toEqual(expectedOutput)
+})
 
 test('remove all description fields', () => {
-	const openapiFile = "test/openapi/town.yaml";
-	const overlayFile = "test/overlays/remove-descriptions.yaml";
-	const expectedFile = "test/expected/town-remove-descriptions.yaml";
-	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+  const openapiFile = 'test/openapi/town.yaml'
+  const overlayFile = 'test/overlays/remove-descriptions.yaml'
+  const expectedFile = 'test/expected/town-remove-descriptions.yaml'
+  const expectedOutput = fs.readFileSync(expectedFile, 'utf8')
 
-	const result = overlayFiles(openapiFile, overlayFile);
+  const result = overlayFiles(openapiFile, overlayFile)
 
-	expect(result).toEqual(expectedOutput);
-});
+  expect(result).toEqual(expectedOutput)
+})
 
 test('remove a server array entry', () => {
-	const openapiFile = "test/openapi/openapi-with-servers.yaml";
-	const overlayFile = "test/overlays/remove-server.yaml";
-	const expectedFile = "test/expected/one-less-server.yaml";
-	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+  const openapiFile = 'test/openapi/openapi-with-servers.yaml'
+  const overlayFile = 'test/overlays/remove-server.yaml'
+  const expectedFile = 'test/expected/one-less-server.yaml'
+  const expectedOutput = fs.readFileSync(expectedFile, 'utf8')
 
-	const result = overlayFiles(openapiFile, overlayFile);
+  const result = overlayFiles(openapiFile, overlayFile)
 
-	expect(result).toEqual(expectedOutput);
-});
+  expect(result).toEqual(expectedOutput)
+})
 
 test('fail to update a primitive string type', () => {
-	const openapiFile = "test/openapi/immutable.yaml";
-	const overlayFile = "test/overlays/immutable.yaml";
-	const expectedFile = "test/expected/immutable.yaml";
-	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+  const openapiFile = 'test/openapi/immutable.yaml'
+  const overlayFile = 'test/overlays/immutable.yaml'
+  const expectedFile = 'test/expected/immutable.yaml'
+  const expectedOutput = fs.readFileSync(expectedFile, 'utf8')
 
-	const result = overlayFiles(openapiFile, overlayFile);
+  const result = overlayFiles(openapiFile, overlayFile)
 
-	expect(result).toEqual(expectedOutput);
-});
+  expect(result).toEqual(expectedOutput)
+})
 
 test('fail to parse invalid jsonpath expression', () => {
-	const openapiFile = "test/openapi/not-jsonpath.yaml";
-	const overlayFile = "test/overlays/not-jsonpath.yaml";
-	const expectedFile = "test/expected/not-jsonpath.yaml";
-	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+  const openapiFile = 'test/openapi/not-jsonpath.yaml'
+  const overlayFile = 'test/overlays/not-jsonpath.yaml'
+  const expectedFile = 'test/expected/not-jsonpath.yaml'
+  const expectedOutput = fs.readFileSync(expectedFile, 'utf8')
 
-	const result = overlayFiles(openapiFile, overlayFile);
+  const result = overlayFiles(openapiFile, overlayFile)
 
-	expect(result).toEqual(expectedOutput);
-});
+  expect(result).toEqual(expectedOutput)
+})
 
 test('fail to parse invalid overlay document', () => {
-	const openapiFile = "test/openapi/not-overlay.yaml";
-	const overlayFile = "test/overlays/not-overlay.yaml";
-	const expectedFile = "test/expected/not-overlay.yaml";
-	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+  const openapiFile = 'test/openapi/not-overlay.yaml'
+  const overlayFile = 'test/overlays/not-overlay.yaml'
+  const expectedFile = 'test/expected/not-overlay.yaml'
+  const expectedOutput = fs.readFileSync(expectedFile, 'utf8')
 
-	const result = overlayFiles(openapiFile, overlayFile);
+  const result = overlayFiles(openapiFile, overlayFile)
 
-	expect(result).toEqual(expectedOutput);
-});
+  expect(result).toEqual(expectedOutput)
+})
 
 test('overlay document with empty actions is a nop', () => {
-	const openapiFile = "test/openapi/not-overlay.yaml";
-	const overlayFile = "test/overlays/not-overlay.yaml";
-	const expectedFile = "test/expected/not-overlay.yaml";
-	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+  const openapiFile = 'test/openapi/not-overlay.yaml'
+  const overlayFile = 'test/overlays/not-overlay.yaml'
+  const expectedFile = 'test/expected/not-overlay.yaml'
+  const expectedOutput = fs.readFileSync(expectedFile, 'utf8')
 
-	const result = overlayFiles(openapiFile, overlayFile);
+  const result = overlayFiles(openapiFile, overlayFile)
 
-	expect(result).toEqual(expectedOutput);
-});
+  expect(result).toEqual(expectedOutput)
+})
 
 test('remove all matching responses', () => {
-	const openapiFile = "test/openapi/responses.yaml";
-	const overlayFile = "test/overlays/remove-responses.yaml";
-	const expectedFile = "test/expected/remove-responses.yaml";
-	const expectedOutput = fs.readFileSync(expectedFile, 'utf8');
+  const openapiFile = 'test/openapi/responses.yaml'
+  const overlayFile = 'test/overlays/remove-responses.yaml'
+  const expectedFile = 'test/expected/remove-responses.yaml'
+  const expectedOutput = fs.readFileSync(expectedFile, 'utf8')
 
-	const result = overlayFiles(openapiFile, overlayFile);
+  const result = overlayFiles(openapiFile, overlayFile)
 
-	expect(result).toEqual(expectedOutput);
-});
-
+  expect(result).toEqual(expectedOutput)
+})


### PR DESCRIPTION
This commit adds eslint library with the standard ruleset and applies
all rules to the existing codebase.

This will help have a unique code style accross the repository.